### PR TITLE
Adding support for Hyperscipt

### DIFF
--- a/lib/dream_html.ml
+++ b/lib/dream_html.ml
@@ -563,5 +563,5 @@ module Hx = struct
   let vals fmt = string_attr "data-hx-vals" fmt
   let ws_connect fmt = string_attr "data-ws-connect" fmt
   let ws_send = "data-ws-send", ""
-  let hs = string_attr "_" fmt
+  let hs fmt = string_attr "_" fmt
 end

--- a/lib/dream_html.ml
+++ b/lib/dream_html.ml
@@ -563,4 +563,5 @@ module Hx = struct
   let vals fmt = string_attr "data-hx-vals" fmt
   let ws_connect fmt = string_attr "data-ws-connect" fmt
   let ws_send = "data-ws-send", ""
+  let hs = string_attr "_" fmt
 end

--- a/lib/dream_html.mli
+++ b/lib/dream_html.mli
@@ -664,6 +664,9 @@ module Hx : sig
   val vals : _ string_attr
   val ws_connect : _ string_attr
   val ws_send : attr
+  
+  val hs: _ string_attr
+  (** Note that the value of this attribute is not escaped. *)
 end
 
 (** {2 Interop example–Markdown to HTML}


### PR DESCRIPTION
htmx says that [hyperscript](https://htmx.org/docs/#hyperscript) is meant to be used in tandem with itself for some frontend logic, but this library does not let you use the required "_" tag in html to use it.

This PR aims to add support for this "_" tag with `hs` `attr`.