### PR TITLE
Add support for web components

### DIFF
--- a/lib/dream_html.ml
+++ b/lib/dream_html.ml
@@ -237,6 +237,9 @@ module Attr = struct
       | `anonymous -> "anonymous"
       | `use_credentials -> "use-credentials" )
 
+  let custom_attr name = name, ""
+  let custom_string_attr name fmt = string_attr name fmt
+
   let data fmt = uri_attr "data" fmt
   let datetime fmt = string_attr "datetime" fmt
 
@@ -521,6 +524,7 @@ module Tag = struct
   let var = std_tag "var"
   let video = std_tag "video"
   let wbr = void_tag "wbr"
+  let web_component name = std_tag name
 end
 
 module Hx = struct

--- a/lib/dream_html.mli
+++ b/lib/dream_html.mli
@@ -305,6 +305,12 @@ module Attr : sig
   val controls : attr
   val coords : _ string_attr
   val crossorigin : [< `anonymous | `use_credentials] to_attr
+
+  val custom_attr : string -> attr
+  val custom_string_attr : string -> _ string_attr
+  (** A custom attribute. The name must be lowercase and not start with "data-". *)
+
+
   val data : _ string_attr
   val datetime : _ string_attr
   val decoding : [< `sync | `async | `auto] to_attr
@@ -586,6 +592,9 @@ module Tag : sig
   val var : std_tag
   val video : std_tag
   val wbr : void_tag
+
+  val web_component : string -> std_tag
+  (** A web component. The name is not escaped. *)
 end
 
 (** {2 htmx attributes} *)

--- a/test/dream_html_test.ml
+++ b/test/dream_html_test.ml
@@ -52,6 +52,8 @@ let node =
                       autocapitalize `words ]
                     "super";
                   hr [(if true then class_ "super" else null)];
-                  greet "Bob" ] ] ] ]
+                  greet "Bob";
+                  web_component "some-random-wc" [custom_string_attr "my-attr" "1"; custom_attr "another-attr"] []
+                  ] ] ] ]
 
 let () = node |> to_string |> print_endline

--- a/test/expected.html
+++ b/test/expected.html
@@ -15,6 +15,7 @@
 </div>
 <textarea required data-hx-trigger="keyup[target.value.trim() != '']" autocapitalize="words">super</textarea>
 <hr class="super"><p id="greet-Bob">Hello, Bob!</p>
+<some-random-wc my-attr="1" another-attr></some-random-wc>
 </main>
 </body>
 </html>


### PR DESCRIPTION
I'm starting to love to use this library.

For my project, I sometimes need to use specific WebComponents. Do you think that letting the user add any `attr` or any `named-tag` into the parser could be useful? Is it something that your library would accept?