### PR TITLE
Add std_tag handler on index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,6 +151,27 @@ open HTML</code></pre>
                 'option': 1, 'script': 1, 'style': 1, 'textarea': 1, 'title': 1
               };
 
+              const htmlTags = {
+                ...voidTags,
+                ...textTags,
+                'a': 1, 'abbr': 1, 'address': 1, 'article': 1, 'aside': 1,
+                'audio': 1, 'b': 1, 'bdi': 1, 'bdo': 1, 'blockquote': 1, 'body': 1,
+                'button': 1, 'canvas': 1, 'caption': 1, 'cite': 1, 'code': 1,
+                'colgroup': 1, 'data': 1, 'datalist': 1, 'dd': 1, 'del': 1, 'details': 1,
+                'dfn': 1, 'dialog': 1, 'div': 1, 'dl': 1, 'dt': 1, 'em': 1,
+                'fieldset': 1, 'figcaption': 1, 'figure': 1, 'footer': 1, 'form': 1, 'h1': 1,
+                'h2': 1, 'h3': 1, 'h4': 1, 'h5': 1, 'h6': 1, 'head': 1, 'header': 1, 'hgroup': 1,
+                'html': 1, 'i': 1, 'iframe': 1, 'ins': 1, 'kbd': 1, 
+                'label': 1, 'legend': 1, 'li': 1, 'main': 1, 'map': 1, 'mark': 1, 'menu': 1,
+                'meter': 1, 'nav': 1, 'noscript': 1, 'object': 1, 'ol': 1, 'optgroup': 1,
+                'output': 1, 'p': 1, 'param': 1, 'picture': 1, 'pre': 1, 'progress': 1, 
+                'q': 1, 'rp': 1, 'rt': 1, 'ruby': 1, 's': 1, 'samp': 1, 'section': 1, 
+                'select': 1, 'small': 1, 'span': 1, 'strong': 1, 'sub': 1, 
+                'summary': 1, 'sup': 1, 'table': 1, 'tbody': 1, 'td': 1, 'template': 1, 
+                'tfoot': 1, 'th': 1, 'thead': 1, 'time': 1, 'tr': 1, 'u': 1,
+                'ul': 1, 'var': 1, 'video': 1
+              };
+
               const attr = name => {
                 if (suffixAttrs[name]) return name + '_';
                 if (ariaAttrs[name]) return 'Aria.' + name.slice(5);
@@ -224,7 +245,12 @@ open HTML</code></pre>
                         inHead = false;
                       }
 
-                      res += name;
+                      if (htmlTags[name]) {
+                        res += name;
+                      } else {
+                        res += 'std_tag ' + stringify(name);
+                      }
+
                       res += ' [';
                       for (const a of t.attributes) {
                         res += attr(a.name);


### PR DESCRIPTION
## Why

There is no way to create a dream-html from a HTML with custom tag, such as web-components

## How

- Added a object with all tags to find by object lookup if its a HTML tag or not
- Add std_tag when its custom tag

## Screenshot

![image](https://github.com/yawaramin/dream-html/assets/35539594/44014d53-a57f-4a66-bb91-9de1b97677e9)