### PR TITLE
Add pure-html pin to READEME.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ opam update
 opam install dream-html
 ```
 
-Alternatively, to install the latest commit that may not have been released yet:
+Alternatively, to install the latest commit that may not have been released yet, run _one_ of the following depending on which package you need:
 
 ```
 opam pin add pure-html git+https://github.com/yawaramin/dream-html

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ opam install dream-html
 Alternatively, to install the latest commit that may not have been released yet:
 
 ```
+opam pin add pure-html git+https://github.com/yawaramin/dream-html
 opam pin add dream-html git+https://github.com/yawaramin/dream-html
 ```
 


### PR DESCRIPTION
When this repository has higher version than published versions, pinning only `dream-html` will likely complete with errors, because opam doesn't know about the corresponding version of `pure-html`:
![image](https://github.com/user-attachments/assets/56cc7c55-01ad-4f63-80ff-dfbbc59a2634)
Added pin for `pure-html` in the `READEME.md` pin instructions.